### PR TITLE
COMPASS-4077 - Make package work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - '4.2.1'
-  - 6
-  - 7
+  - 10
+  - 12
+  - 14
 before_install:
   - npm install -g npm@3
   - npm config set loglevel error

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,7 @@ node_js:
   - 10
   - 12
   - 14
-before_install:
-  - npm install -g npm@3
-  - npm config set loglevel error
-  - npm config -g list -l
-  - npm --version
-script: npm run-script ci
+script: npm run ci
 cache:
   directories:
     - node_modules

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var fs = require('fs');
 var path = require('path');
 var del = require('del');
 var run = require('electron-installer-run');
-var glob = require('glob');
 var async = require('async');
 var chalk = require('chalk');
 var figures = require('figures');
@@ -36,14 +35,14 @@ function runCodesign(src, opts, fn) {
     hardenedRuntime: true,
     identity: opts.identity,
     'gatekeeper-assess': false
-  }, (err) => {
+  }, function(err) {
     if (err) {
       fn(new Error('codesign failed ' + path.basename(src)
         + ': ' + err.message));
       return;
     }
     fn(null, src);
-  })
+  });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "electron-installer-run": "^0.1.0",
     "electron-osx-sign": "^0.4.16",
     "figures": "^2.0.0",
-    "glob": "^7.1.1",
     "minimist": "^1.2.0"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
This package could not really have worked in its current state, considering that
it was passing e.g. functions where an array would have been expected.

The changes here simplify the code and allow us to bump the version we use
in `hadron-build`.