### PR TITLE
COMPASS-4077 - Add entitlements file with sensible defaults

### DIFF
--- a/entitlements.xml
+++ b/entitlements.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key><true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key><true/>
+    <key>com.apple.security.cs.disable-library-validation</key><true/>
+</dict>
+</plist>

--- a/index.js
+++ b/index.js
@@ -30,11 +30,16 @@ function cleanup(opts, fn) {
 }
 
 function runCodesign(src, opts, fn) {
+  var entitlementsFile = opts.entitlements ||
+    path.resolve(__dirname, 'entitlements.xml');
   sign({
     app: src,
     hardenedRuntime: true,
     identity: opts.identity,
-    'gatekeeper-assess': false
+    'gatekeeper-assess': false,
+    entitlements: entitlementsFile,
+    'entitlements-inherit': entitlementsFile,
+    'entitlements-loginheler': entitlementsFile
   }, function(err) {
     if (err) {
       fn(new Error('codesign failed ' + path.basename(src)

--- a/package-lock.json
+++ b/package-lock.json
@@ -514,9 +514,9 @@
       }
     },
     "electron-osx-sign": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.16.tgz",
-      "integrity": "sha512-ziMWfc3NmQlwnWLW6EaZq8nH2BWVng/atX5GWsGwhexJYpdW6hsg//MkAfRTRx1kR3Veiqkeiog1ibkbA4x0rg==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.17.tgz",
+      "integrity": "sha512-wUJPmZJQCs1zgdlQgeIpRcvrf7M5/COQaOV68Va1J/SgmWx5KL2otgg+fAae7luw6qz9R8Gvu/Qpe9tAOu/3xQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "compare-version": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^2.2.0",
     "del": "^2.1.0",
     "electron-installer-run": "^0.1.0",
-    "electron-osx-sign": "^0.4.16",
+    "electron-osx-sign": "^0.4.17",
     "figures": "^2.0.0",
     "minimist": "^1.2.0"
   },


### PR DESCRIPTION
Add an entitlements file that allows creating an executable
which is able to run on macOS, and use that by default. It should cover
basic Electron use cases, and does work for Compass.